### PR TITLE
Removal of the Ticket Settings string

### DIFF
--- a/lang/English/modules/tickets.php
+++ b/lang/English/modules/tickets.php
@@ -91,7 +91,6 @@ define('attachment_too_large', "%s (%s) is larger than the maximum allowed size 
 define('attachment_forbidden_type', "The file type of %s may not be uploaded.");
 define('attachment_directory_not_writable', "Unable to save the attached files. The specified save directory is not writable.");
 define('attachment_invalid_file_count', "The amount of files sent to the server was invalid. Only a maximum of %s may be uploaded");
-define('ticket_settings', "Ticket Settings");
 define('ratings_enabled', "Ratings");
 define('ratings_enabled_info', "Set if rating responses should be allowed.");
 define('attachments_enabled', "Attachments");


### PR DESCRIPTION
since this PR has been accepted
https://github.com/OpenGamePanel/OGP-Website/pull/270 it makes the
string localized in administration menu not only when in the ticket
module pages now, so this string is now a duplicate not needed anymore